### PR TITLE
Rebuild with fixed jsondiff version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
 
 requirements:
   host:


### PR DESCRIPTION
Accidentally committed the previous fix directly to main. Creating a new branch with updated build number.